### PR TITLE
Add support for XAnim asset type

### DIFF
--- a/Call of Duty FastFile Editor/GameDefinitions/CoD4Definition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/CoD4Definition.cs
@@ -22,6 +22,7 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public const byte RawFileAssetType = 0x21;     // 33
         public const byte LocalizeAssetType = 0x18;    // 24
         public const byte StringTableAssetType = 0x22; // 34
+        public const byte XAnimAssetType = 0x02;       // 2
     }
 
     /// <summary>

--- a/Call of Duty FastFile Editor/GameDefinitions/CoD4GameDefinition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/CoD4GameDefinition.cs
@@ -15,6 +15,7 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public override byte[] VersionBytes => CoD4Definition.VersionBytes;
         public override byte RawFileAssetType => CoD4Definition.RawFileAssetType;
         public override byte LocalizeAssetType => CoD4Definition.LocalizeAssetType;
+        public override byte XAnimAssetType => CoD4Definition.XAnimAssetType;
 
         public override string GetAssetTypeName(int assetType)
         {
@@ -27,7 +28,9 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
 
         public override bool IsSupportedAssetType(int assetType)
         {
-            return assetType == RawFileAssetType || assetType == LocalizeAssetType;
+            return assetType == RawFileAssetType ||
+                   assetType == LocalizeAssetType ||
+                   assetType == XAnimAssetType;
         }
     }
 }

--- a/Call of Duty FastFile Editor/GameDefinitions/CoD5Definition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/CoD5Definition.cs
@@ -24,6 +24,7 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public const byte MenuFileAssetType = 0x17;    // 23
         public const byte MaterialAssetType = 0x06;    // 6
         public const byte TechSetAssetType = 0x09;     // 9
+        public const byte XAnimAssetType = 0x04;       // 4
     }
 
     /// <summary>

--- a/Call of Duty FastFile Editor/GameDefinitions/CoD5GameDefinition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/CoD5GameDefinition.cs
@@ -18,6 +18,7 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public override byte RawFileAssetType => CoD5Definition.RawFileAssetType;
         public override byte LocalizeAssetType => CoD5Definition.LocalizeAssetType;
         public override byte MenuFileAssetType => CoD5Definition.MenuFileAssetType;
+        public override byte XAnimAssetType => CoD5Definition.XAnimAssetType;
         public byte MaterialAssetType => CoD5Definition.MaterialAssetType;
         public byte TechSetAssetType => CoD5Definition.TechSetAssetType;
 
@@ -40,7 +41,8 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
                    assetType == LocalizeAssetType ||
                    assetType == MenuFileAssetType ||
                    assetType == MaterialAssetType ||
-                   assetType == TechSetAssetType;
+                   assetType == TechSetAssetType ||
+                   assetType == XAnimAssetType;
         }
 
         public override bool IsMaterialType(int assetType) => assetType == MaterialAssetType;

--- a/Call of Duty FastFile Editor/GameDefinitions/GameDefinitionBase.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/GameDefinitionBase.cs
@@ -20,13 +20,15 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public abstract byte RawFileAssetType { get; }
         public abstract byte LocalizeAssetType { get; }
         public virtual byte MenuFileAssetType => 0; // Default 0 means not supported
+        public abstract byte XAnimAssetType { get; }
 
         public virtual bool IsRawFileType(int assetType) => assetType == RawFileAssetType;
         public virtual bool IsLocalizeType(int assetType) => assetType == LocalizeAssetType;
         public virtual bool IsMenuFileType(int assetType) => MenuFileAssetType != 0 && assetType == MenuFileAssetType;
+        public virtual bool IsXAnimType(int assetType) => assetType == XAnimAssetType;
         public virtual bool IsMaterialType(int assetType) => false; // Override in game-specific definitions
         public virtual bool IsTechSetType(int assetType) => false; // Override in game-specific definitions
-        public virtual bool IsSupportedAssetType(int assetType) => IsRawFileType(assetType) || IsLocalizeType(assetType) || IsMenuFileType(assetType);
+        public virtual bool IsSupportedAssetType(int assetType) => IsRawFileType(assetType) || IsLocalizeType(assetType) || IsMenuFileType(assetType) || IsXAnimType(assetType);
         public abstract string GetAssetTypeName(int assetType);
 
         /// <summary>
@@ -207,7 +209,258 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
             return TechSetParser.ParseTechSet(zoneData, offset, isBigEndian: true);
         }
 
+        /// <summary>
+        /// Default XAnim parsing.
+        ///
+        /// XAnimParts structure for CoD4/WaW (88 bytes header):
+        /// [FF FF FF FF] - name pointer (inline)
+        /// [2 bytes] dataByteCount
+        /// [2 bytes] dataShortCount
+        /// [2 bytes] dataIntCount
+        /// [2 bytes] randomDataByteCount
+        /// [2 bytes] randomDataIntCount
+        /// [2 bytes] numframes
+        /// [1 byte] bLoop
+        /// [1 byte] bDelta
+        /// [12 bytes] boneCount array
+        /// [1 byte] notifyCount
+        /// [1 byte] assetType
+        /// [1 byte] pad
+        /// [1 byte] padding
+        /// [4 bytes] randomDataShortCount
+        /// [4 bytes] indexCount
+        /// [4 bytes] framerate (float)
+        /// [4 bytes] frequency (float)
+        /// [4 bytes] names pointer
+        /// [4 bytes] dataByte pointer
+        /// [4 bytes] dataShort pointer
+        /// [4 bytes] dataInt pointer
+        /// [4 bytes] randomDataShort pointer
+        /// [4 bytes] randomDataByte pointer
+        /// [4 bytes] randomDataInt pointer
+        /// [4 bytes] indices pointer
+        /// [4 bytes] notify pointer
+        /// [4 bytes] deltaPart pointer
+        /// [name string\0]
+        /// </summary>
+        public virtual XAnimParts? ParseXAnim(byte[] zoneData, int offset)
+        {
+            Debug.WriteLine($"[{ShortName}] ParseXAnim at offset 0x{offset:X}");
+
+            // First try structure-based parsing at exact offset (with debug output)
+            var result = TryParseXAnimStructure(zoneData, offset, debugOutput: true);
+            if (result != null)
+            {
+                return result;
+            }
+
+            // If exact position failed, search forward for a valid XAnim header
+            for (int searchOffset = offset + 1; searchOffset < Math.Min(offset + 256, zoneData.Length - 88); searchOffset++)
+            {
+                result = TryParseXAnimStructure(zoneData, searchOffset, debugOutput: false);
+                if (result != null)
+                {
+                    Debug.WriteLine($"[{ShortName}] Found XAnim at adjusted offset 0x{searchOffset:X} (was 0x{offset:X})");
+                    return result;
+                }
+            }
+
+            Debug.WriteLine($"[{ShortName}] Failed to parse XAnim at 0x{offset:X}");
+            return null;
+        }
+
+        /// <summary>
+        /// Attempts to parse an XAnim at the exact given offset.
+        /// </summary>
+        private XAnimParts? TryParseXAnimStructure(byte[] zoneData, int offset, bool debugOutput = false)
+        {
+            // Need at least 88 bytes for the header structure
+            if (offset + 88 > zoneData.Length)
+            {
+                if (debugOutput) Debug.WriteLine($"[{ShortName}] XAnim: Not enough bytes at 0x{offset:X}");
+                return null;
+            }
+
+            // Read the name pointer (should be 0xFFFFFFFF for inline)
+            uint namePointer = ReadUInt32BE(zoneData, offset);
+            if (namePointer != 0xFFFFFFFF && namePointer != 0x00000000)
+            {
+                if (debugOutput) Debug.WriteLine($"[{ShortName}] XAnim: Invalid name pointer 0x{namePointer:X8} at 0x{offset:X}");
+                return null;
+            }
+
+            // Read header fields (big-endian for PS3/Xbox 360)
+            // XAnimParts structure - verified from actual zone file hex dump:
+            // 0x00: name pointer (4 bytes) - 0xFFFFFFFF if inline
+            // 0x04: dataByteCount (2 bytes)
+            // 0x06: dataShortCount (2 bytes)
+            // 0x08: dataIntCount (2 bytes)
+            // 0x0A: randomDataByteCount (2 bytes)
+            // 0x0C: randomDataIntCount (2 bytes)
+            // 0x0E: numframes (2 bytes)
+            // 0x10: bLoop (1 byte)
+            // 0x11: bDelta (1 byte)
+            // 0x12-0x1D: boneCount[12] (12 bytes)
+            // 0x1E: notifyCount (1 byte)
+            // 0x1F: assetType (1 byte)
+            // 0x20: randomDataShortCount (4 bytes)
+            // 0x24: indexCount (4 bytes)
+            // 0x28: unknown/padding (4 bytes) - observed as 0x00000000
+            // 0x2C: framerate (4 bytes) - e.g., 0x41F00000 = 30.0 fps
+            // 0x30: frequency (4 bytes) - e.g., 0x3FC00000 = 1.5
+            // 0x34+: pointers (dataByte, dataShort, dataInt, randomDataShort, randomDataByte, randomDataInt, indices, notify, deltaPart)
+            // 0x58+: name string (when name pointer is 0xFFFFFFFF)
+
+            ushort dataByteCount = ReadUInt16BE(zoneData, offset + 0x04);
+            ushort dataShortCount = ReadUInt16BE(zoneData, offset + 0x06);
+            ushort dataIntCount = ReadUInt16BE(zoneData, offset + 0x08);
+            ushort randomDataByteCount = ReadUInt16BE(zoneData, offset + 0x0A);
+            ushort randomDataIntCount = ReadUInt16BE(zoneData, offset + 0x0C);
+            ushort numframes = ReadUInt16BE(zoneData, offset + 0x0E);
+            bool bLoop = zoneData[offset + 0x10] != 0;
+            bool bDelta = zoneData[offset + 0x11] != 0;
+
+            // Read bone count array (12 bytes at offset 0x12)
+            byte[] boneCount = new byte[12];
+            Array.Copy(zoneData, offset + 0x12, boneCount, 0, 12);
+
+            byte notifyCount = zoneData[offset + 0x1E];
+            byte assetType = zoneData[offset + 0x1F];
+
+            uint randomDataShortCount = ReadUInt32BE(zoneData, offset + 0x20);
+            uint indexCount = ReadUInt32BE(zoneData, offset + 0x24);
+            // Skip 0x28 (unknown/padding field)
+            float framerate = ReadFloatBE(zoneData, offset + 0x2C);  // Fixed: was 0x28
+            float frequency = ReadFloatBE(zoneData, offset + 0x30);  // Fixed: was 0x2C
+
+            if (debugOutput)
+            {
+                Debug.WriteLine($"[{ShortName}] XAnim at 0x{offset:X}: namePtr=0x{namePointer:X8}, frames={numframes}, fps={framerate:F1}, dataByte={dataByteCount}, dataShort={dataShortCount}, dataInt={dataIntCount}");
+                // Dump raw bytes at key offsets for debugging
+                string bytesAt2C = $"{zoneData[offset + 0x2C]:X2} {zoneData[offset + 0x2D]:X2} {zoneData[offset + 0x2E]:X2} {zoneData[offset + 0x2F]:X2}";
+                Debug.WriteLine($"[{ShortName}] XAnim: Raw bytes at 0x2C (framerate): {bytesAt2C}");
+            }
+
+            // Validate: framerate should be reasonable (1-120 fps typically)
+            // Also check for NaN and infinity
+            if (float.IsNaN(framerate) || float.IsInfinity(framerate) || framerate < 0.1f || framerate > 1000f)
+            {
+                if (debugOutput) Debug.WriteLine($"[{ShortName}] XAnim: Invalid framerate {framerate} at 0x{offset:X}");
+                return null;
+            }
+
+            // Validate: numframes should be reasonable
+            if (numframes == 0 || numframes > 100000)
+            {
+                if (debugOutput) Debug.WriteLine($"[{ShortName}] XAnim: Invalid numframes {numframes} at 0x{offset:X}");
+                return null;
+            }
+
+            // After the fixed header fields (ending at 0x34), there are pointer fields.
+            // Based on hex dump analysis:
+            // - 0x34-0x57: Pointer fields (9 pointers * 4 bytes = 36 bytes, mix of 0xFFFFFFFF and 0x00000000)
+            // - 0x58+: Name string (when name pointer is 0xFFFFFFFF)
+            // We search for the name starting from offset + 0x34
+
+            string name = "";
+            int nameOffset = 0;
+
+            // Search for the name string starting from offset + 0x34 (after fixed fields)
+            // Name is typically around offset 0x58 (88 bytes from header start)
+            for (int searchStart = offset + 0x34; searchStart < offset + 256 && searchStart < zoneData.Length - 10; searchStart++)
+            {
+                // Skip 0xFF and 0x00 bytes (pointer placeholders and nulls)
+                if (zoneData[searchStart] == 0xFF || zoneData[searchStart] == 0x00)
+                    continue;
+
+                // Check if this looks like a valid name start (lowercase letter or 'p' for prefix)
+                byte b = zoneData[searchStart];
+                if ((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z'))
+                {
+                    string candidate = ReadNullTerminatedString(zoneData, searchStart);
+                    if (!string.IsNullOrEmpty(candidate) && candidate.Length >= 3 && candidate.Length <= 128)
+                    {
+                        // Check if it looks like an animation name (contains underscore and valid chars)
+                        bool looksValid = candidate.Contains('_') &&
+                                          candidate.All(c => char.IsLetterOrDigit(c) || c == '_' || c == '.' || c == '/' || c == '\\');
+                        if (looksValid)
+                        {
+                            name = candidate;
+                            nameOffset = searchStart;
+                            if (debugOutput) Debug.WriteLine($"[{ShortName}] XAnim: Found name '{name}' at 0x{nameOffset:X} (header at 0x{offset:X})");
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(name))
+            {
+                if (debugOutput) Debug.WriteLine($"[{ShortName}] XAnim: Could not find valid name at 0x{offset:X}");
+                return null;
+            }
+
+            Debug.WriteLine($"[{ShortName}] XAnim header at 0x{offset:X}: name='{name}', frames={numframes}, fps={framerate:F1}, bones={boneCount.Sum(b => (int)b)}");
+
+            // Calculate end offset (header + name + null terminator)
+            // The actual data follows but we're just parsing the header for now
+            int endOffset = nameOffset + name.Length + 1;
+
+            // Skip past any inline data based on the counts
+            // This is a simplified calculation - actual size depends on data alignment
+            int estimatedDataSize =
+                dataByteCount +
+                (dataShortCount * 2) +
+                (dataIntCount * 4) +
+                randomDataByteCount +
+                (int)(randomDataShortCount * 2) +
+                (randomDataIntCount * 4);
+
+            // Add some buffer for alignment and additional structures
+            endOffset += estimatedDataSize;
+
+            return new XAnimParts
+            {
+                Name = name,
+                DataByteCount = dataByteCount,
+                DataShortCount = dataShortCount,
+                DataIntCount = dataIntCount,
+                RandomDataByteCount = randomDataByteCount,
+                RandomDataIntCount = randomDataIntCount,
+                NumFrames = numframes,
+                IsLooping = bLoop,
+                HasDelta = bDelta,
+                BoneCounts = boneCount,
+                NotifyCount = notifyCount,
+                AssetType = assetType,
+                RandomDataShortCount = randomDataShortCount,
+                IndexCount = indexCount,
+                Framerate = framerate,
+                Frequency = frequency,
+                StartOffset = offset,
+                EndOffset = endOffset,
+                AdditionalData = $"{ShortName} structure-based parse; {numframes} frames at {framerate:F1} fps"
+            };
+        }
+
         #region Helper Methods
+
+        protected static ushort ReadUInt16BE(byte[] data, int offset)
+        {
+            if (offset + 2 > data.Length) return 0;
+            return (ushort)((data[offset] << 8) | data[offset + 1]);
+        }
+
+        protected static float ReadFloatBE(byte[] data, int offset)
+        {
+            if (offset + 4 > data.Length) return 0;
+            byte[] bytes = new byte[4];
+            bytes[0] = data[offset + 3];
+            bytes[1] = data[offset + 2];
+            bytes[2] = data[offset + 1];
+            bytes[3] = data[offset];
+            return BitConverter.ToSingle(bytes, 0);
+        }
 
         protected static uint ReadUInt32BE(byte[] data, int offset)
         {

--- a/Call of Duty FastFile Editor/GameDefinitions/IGameDefinition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/IGameDefinition.cs
@@ -49,9 +49,19 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         byte MenuFileAssetType { get; }
 
         /// <summary>
+        /// Asset type ID for xanim assets.
+        /// </summary>
+        byte XAnimAssetType { get; }
+
+        /// <summary>
         /// Checks if the given asset type value is a rawfile.
         /// </summary>
         bool IsRawFileType(int assetType);
+
+        /// <summary>
+        /// Checks if the given asset type value is an xanim.
+        /// </summary>
+        bool IsXAnimType(int assetType);
 
         /// <summary>
         /// Checks if the given asset type value is a menufile.
@@ -122,5 +132,13 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         /// <param name="offset">Starting offset to parse from.</param>
         /// <returns>Parsed TechSetAsset, or null if parsing failed.</returns>
         TechSetAsset? ParseTechSet(byte[] zoneData, int offset);
+
+        /// <summary>
+        /// Parses an xanim asset from the zone data at the given offset.
+        /// </summary>
+        /// <param name="zoneData">The zone file data.</param>
+        /// <param name="offset">Starting offset to parse from.</param>
+        /// <returns>Parsed XAnimParts, or null if parsing failed.</returns>
+        XAnimParts? ParseXAnim(byte[] zoneData, int offset);
     }
 }

--- a/Call of Duty FastFile Editor/GameDefinitions/MW2Definition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/MW2Definition.cs
@@ -22,6 +22,7 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public const byte RawFileAssetType = 0x23;     // 35
         public const byte LocalizeAssetType = 0x1A;    // 26
         public const byte StringTableAssetType = 0x24; // 36
+        public const byte XAnimAssetType = 0x02;       // 2
 
         // MW2-specific: Extended header info
         public const int ExtendedHeaderEntrySize = 0x14;  // 20 bytes per entry on PS3

--- a/Call of Duty FastFile Editor/GameDefinitions/MW2GameDefinition.cs
+++ b/Call of Duty FastFile Editor/GameDefinitions/MW2GameDefinition.cs
@@ -18,6 +18,7 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
         public override byte RawFileAssetType => MW2Definition.RawFileAssetType;
         public override byte LocalizeAssetType => MW2Definition.LocalizeAssetType;
         public override byte MenuFileAssetType => 0x19; // menufile type for MW2
+        public override byte XAnimAssetType => MW2Definition.XAnimAssetType;
 
         public override string GetAssetTypeName(int assetType)
         {
@@ -30,7 +31,10 @@ namespace Call_of_Duty_FastFile_Editor.GameDefinitions
 
         public override bool IsSupportedAssetType(int assetType)
         {
-            return assetType == RawFileAssetType || assetType == LocalizeAssetType || assetType == MenuFileAssetType;
+            return assetType == RawFileAssetType ||
+                   assetType == LocalizeAssetType ||
+                   assetType == MenuFileAssetType ||
+                   assetType == XAnimAssetType;
         }
 
         /// <summary>

--- a/Call of Duty FastFile Editor/Models/AssetRecordCollection.cs
+++ b/Call of Duty FastFile Editor/Models/AssetRecordCollection.cs
@@ -15,6 +15,7 @@ namespace Call_of_Duty_FastFile_Editor.Models
         public List<MenuList> MenuLists { get; set; } = new List<MenuList>();
         public List<MaterialAsset> Materials { get; set; } = new List<MaterialAsset>();
         public List<TechSetAsset> TechSets { get; set; } = new List<TechSetAsset>();
+        public List<XAnimParts> XAnims { get; set; } = new List<XAnimParts>();
         public List<ZoneAssetRecord> UpdatedRecords { get; set; } = new List<ZoneAssetRecord>();
     }
 

--- a/Call of Duty FastFile Editor/Models/XAnimParts.cs
+++ b/Call of Duty FastFile Editor/Models/XAnimParts.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+
+namespace Call_of_Duty_FastFile_Editor.Models
+{
+    /// <summary>
+    /// Represents an XAnim (animation) asset from a zone file.
+    ///
+    /// Structure for CoD4/WaW:
+    /// struct XAnimParts {
+    ///   const char *name;              // 4 bytes - FF FF FF FF if inline
+    ///   unsigned __int16 dataByteCount;
+    ///   unsigned __int16 dataShortCount;
+    ///   unsigned __int16 dataIntCount;
+    ///   unsigned __int16 randomDataByteCount;
+    ///   unsigned __int16 randomDataIntCount;
+    ///   unsigned __int16 numframes;
+    ///   bool bLoop;
+    ///   bool bDelta;
+    ///   char boneCount[12];
+    ///   char notifyCount;
+    ///   char assetType;
+    ///   bool pad;
+    ///   unsigned int randomDataShortCount;
+    ///   unsigned int indexCount;
+    ///   float framerate;
+    ///   float frequency;
+    ///   ScriptString *names;           // 4 bytes - pointer
+    ///   char *dataByte;                // 4 bytes - pointer
+    ///   __int16 *dataShort;            // 4 bytes - pointer
+    ///   int *dataInt;                  // 4 bytes - pointer
+    ///   __int16 *randomDataShort;      // 4 bytes - pointer
+    ///   char *randomDataByte;          // 4 bytes - pointer
+    ///   int *randomDataInt;            // 4 bytes - pointer
+    ///   XAnimIndices indices;          // 4 bytes - pointer
+    ///   XAnimNotifyInfo *notify;       // 4 bytes - pointer
+    ///   XAnimDeltaPart *deltaPart;     // 4 bytes - pointer
+    /// };
+    /// </summary>
+    public class XAnimParts
+    {
+        /// <summary>
+        /// Animation name/path.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Number of data bytes.
+        /// </summary>
+        public ushort DataByteCount { get; set; }
+
+        /// <summary>
+        /// Number of data shorts.
+        /// </summary>
+        public ushort DataShortCount { get; set; }
+
+        /// <summary>
+        /// Number of data ints.
+        /// </summary>
+        public ushort DataIntCount { get; set; }
+
+        /// <summary>
+        /// Number of random data bytes.
+        /// </summary>
+        public ushort RandomDataByteCount { get; set; }
+
+        /// <summary>
+        /// Number of random data ints.
+        /// </summary>
+        public ushort RandomDataIntCount { get; set; }
+
+        /// <summary>
+        /// Number of animation frames.
+        /// </summary>
+        public ushort NumFrames { get; set; }
+
+        /// <summary>
+        /// Whether the animation loops.
+        /// </summary>
+        public bool IsLooping { get; set; }
+
+        /// <summary>
+        /// Whether the animation has delta data.
+        /// </summary>
+        public bool HasDelta { get; set; }
+
+        /// <summary>
+        /// Bone counts array (12 bytes).
+        /// </summary>
+        public byte[] BoneCounts { get; set; } = new byte[12];
+
+        /// <summary>
+        /// Number of notify events.
+        /// </summary>
+        public byte NotifyCount { get; set; }
+
+        /// <summary>
+        /// Asset type identifier.
+        /// </summary>
+        public byte AssetType { get; set; }
+
+        /// <summary>
+        /// Number of random data shorts.
+        /// </summary>
+        public uint RandomDataShortCount { get; set; }
+
+        /// <summary>
+        /// Index count.
+        /// </summary>
+        public uint IndexCount { get; set; }
+
+        /// <summary>
+        /// Animation framerate (frames per second).
+        /// </summary>
+        public float Framerate { get; set; }
+
+        /// <summary>
+        /// Animation frequency.
+        /// </summary>
+        public float Frequency { get; set; }
+
+        /// <summary>
+        /// Total bone count (sum of all boneCount entries).
+        /// </summary>
+        public int TotalBoneCount => CalculateTotalBoneCount();
+
+        /// <summary>
+        /// Animation duration in seconds.
+        /// </summary>
+        public float Duration => Framerate > 0 ? NumFrames / Framerate : 0;
+
+        /// <summary>
+        /// Start offset in the zone file.
+        /// </summary>
+        public int StartOffset { get; set; }
+
+        /// <summary>
+        /// End offset in the zone file.
+        /// </summary>
+        public int EndOffset { get; set; }
+
+        /// <summary>
+        /// Additional parsing information.
+        /// </summary>
+        public string AdditionalData { get; set; } = string.Empty;
+
+        private int CalculateTotalBoneCount()
+        {
+            int total = 0;
+            if (BoneCounts != null)
+            {
+                foreach (var count in BoneCounts)
+                    total += count;
+            }
+            return total;
+        }
+
+        /// <summary>
+        /// Gets a summary of the animation properties.
+        /// </summary>
+        public string GetSummary()
+        {
+            return $"{NumFrames} frames, {Framerate:F1} fps, {Duration:F2}s, {TotalBoneCount} bones" +
+                   (IsLooping ? ", loops" : "") +
+                   (HasDelta ? ", delta" : "");
+        }
+    }
+}

--- a/Call of Duty FastFile Editor/UI/AssetSelectionDialog.cs
+++ b/Call of Duty FastFile Editor/UI/AssetSelectionDialog.cs
@@ -78,7 +78,7 @@ namespace Call_of_Duty_FastFile_Editor.UI
             foreach (var kvp in assetCounts.OrderByDescending(x => x.Value))
             {
                 bool isSupported = kvp.Key == "rawfile" || kvp.Key == "localize" || kvp.Key == "menufile" ||
-                                   kvp.Key == "material" || kvp.Key == "techset";
+                                   kvp.Key == "material" || kvp.Key == "techset" || kvp.Key == "xanim";
                 result.Add(new AssetTypeInfo
                 {
                     TypeName = kvp.Key,

--- a/Call of Duty FastFile Editor/UI/MainWindowForm.Designer.cs
+++ b/Call of Duty FastFile Editor/UI/MainWindowForm.Designer.cs
@@ -87,6 +87,10 @@ namespace Call_of_Duty_FastFile_Editor
             assetPoolListView = new ListView();
             techSetsTabPage = new TabPage();
             techSetsListView = new ListView();
+            xAnimsTabPage = new TabPage();
+            xAnimsListView = new ListView();
+            xAnimsContextMenu = new ContextMenuStrip(components);
+            exportXAnimMenuItem = new ToolStripMenuItem();
             zoneFileTabPage = new TabPage();
             zoneInfoDataGridView = new DataGridView();
             bindingSource1 = new BindingSource(components);
@@ -111,6 +115,8 @@ namespace Call_of_Duty_FastFile_Editor
             tagsTabPage.SuspendLayout();
             assetPoolTabPage.SuspendLayout();
             techSetsTabPage.SuspendLayout();
+            xAnimsTabPage.SuspendLayout();
+            xAnimsContextMenu.SuspendLayout();
             zoneFileTabPage.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)zoneInfoDataGridView).BeginInit();
             ((System.ComponentModel.ISupportInitialize)bindingSource1).BeginInit();
@@ -493,6 +499,7 @@ namespace Call_of_Duty_FastFile_Editor
             mainTabControl.Controls.Add(localizeTabPage);
             mainTabControl.Controls.Add(menuFilesTabPage);
             mainTabControl.Controls.Add(techSetsTabPage);
+            mainTabControl.Controls.Add(xAnimsTabPage);
             mainTabControl.Controls.Add(tagsTabPage);
             mainTabControl.Controls.Add(assetPoolTabPage);
             mainTabControl.Controls.Add(zoneFileTabPage);
@@ -692,6 +699,43 @@ namespace Call_of_Duty_FastFile_Editor
             techSetsListView.View = View.Details;
             techSetsListView.MouseDown += listView_MouseDownCopy;
             //
+            // xAnimsTabPage
+            //
+            xAnimsTabPage.Controls.Add(xAnimsListView);
+            xAnimsTabPage.Location = new Point(4, 24);
+            xAnimsTabPage.Name = "xAnimsTabPage";
+            xAnimsTabPage.Padding = new Padding(3);
+            xAnimsTabPage.Size = new Size(1442, 749);
+            xAnimsTabPage.TabIndex = 10;
+            xAnimsTabPage.Text = "XAnims";
+            xAnimsTabPage.UseVisualStyleBackColor = true;
+            //
+            // xAnimsListView
+            //
+            xAnimsListView.ContextMenuStrip = xAnimsContextMenu;
+            xAnimsListView.Dock = DockStyle.Fill;
+            xAnimsListView.FullRowSelect = true;
+            xAnimsListView.Location = new Point(3, 3);
+            xAnimsListView.Name = "xAnimsListView";
+            xAnimsListView.Size = new Size(1436, 743);
+            xAnimsListView.TabIndex = 0;
+            xAnimsListView.UseCompatibleStateImageBehavior = false;
+            xAnimsListView.View = View.Details;
+            xAnimsListView.MouseDown += listView_MouseDownCopy;
+            //
+            // xAnimsContextMenu
+            //
+            xAnimsContextMenu.Items.AddRange(new ToolStripItem[] { exportXAnimMenuItem });
+            xAnimsContextMenu.Name = "xAnimsContextMenu";
+            xAnimsContextMenu.Size = new Size(180, 26);
+            //
+            // exportXAnimMenuItem
+            //
+            exportXAnimMenuItem.Name = "exportXAnimMenuItem";
+            exportXAnimMenuItem.Size = new Size(179, 22);
+            exportXAnimMenuItem.Text = "Export XAnim Data...";
+            exportXAnimMenuItem.Click += exportXAnimMenuItem_Click;
+            //
             // zoneFileTabPage
             // 
             zoneFileTabPage.Controls.Add(zoneInfoDataGridView);
@@ -752,6 +796,8 @@ namespace Call_of_Duty_FastFile_Editor
             tagsTabPage.ResumeLayout(false);
             assetPoolTabPage.ResumeLayout(false);
             techSetsTabPage.ResumeLayout(false);
+            xAnimsTabPage.ResumeLayout(false);
+            xAnimsContextMenu.ResumeLayout(false);
             zoneFileTabPage.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)zoneInfoDataGridView).EndInit();
             ((System.ComponentModel.ISupportInitialize)bindingSource1).EndInit();
@@ -812,6 +858,10 @@ namespace Call_of_Duty_FastFile_Editor
         private ListView assetPoolListView;
         private TabPage techSetsTabPage;
         private ListView techSetsListView;
+        private TabPage xAnimsTabPage;
+        private ListView xAnimsListView;
+        private ContextMenuStrip xAnimsContextMenu;
+        private ToolStripMenuItem exportXAnimMenuItem;
         private TabPage localizeTabPage;
         private ListView localizeListView;
         private TabPage menuFilesTabPage;


### PR DESCRIPTION
Introduced comprehensive support for the `XAnim` asset type in the `Call_of_Duty_FastFile_Editor` application. This includes:

- Defined `XAnimAssetType` constants in `CoD4Definition.cs`, `CoD5Definition.cs`, `MW2Definition.cs`, and their respective game definition classes.
- Implemented `ParseXAnim` and `TryParseXAnimStructure` methods for parsing `XAnim` assets, including helper methods for big-endian data handling.
- Created the `XAnimParts` model to represent `XAnim` assets with properties like `Name`, `NumFrames`, `Framerate`, and utility methods like `GetSummary`.
- Updated `AssetRecordProcessor.cs` to handle `XAnim` assets during structure-based parsing and pattern matching.
- Added a new `XAnims` tab in the UI to display parsed `XAnim` assets, with options to export raw binary data.
- Updated asset selection and pool logic to include `XAnim` as a supported asset type.
- Enhanced debug logging for better traceability of `XAnim` parsing and processing.

These changes ensure `XAnim` assets are fully integrated into the application, providing users with the ability to parse, view, and export `XAnim` data. #35