### PR TITLE
Bump version to 4.0.0 across projects

### DIFF
--- a/Call of Duty FastFile Editor/Call of Duty FastFile Editor.csproj
+++ b/Call of Duty FastFile Editor/Call of Duty FastFile Editor.csproj
@@ -8,9 +8,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <SelfContained>false</SelfContained>
-    <Version>3.1.0</Version>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Call of Duty FastFile Editor/Constants/ApplicationConstants.cs
+++ b/Call of Duty FastFile Editor/Constants/ApplicationConstants.cs
@@ -3,7 +3,7 @@
     public static class ApplicationConstants
     {
         public const string ProgramName = "Call of Duty Fast File Editor";
-        public const string ProgramVersion = "v3.1.0";
+        public const string ProgramVersion = "v4.0.0";
         public const string About = $"{ProgramName}\n" +
              "Version: " + ProgramVersion + "\n\n" +
              "Developed by primetime43\n\n" +

--- a/FastFileCLI/FastFileCLI.csproj
+++ b/FastFileCLI/FastFileCLI.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
     <AssemblyName>ffcli</AssemblyName>
     <RootNamespace>FastFileCLI</RootNamespace>
-    <Version>3.1.0</Version>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FastFileCompilerGUI/FastFileCompilerGUI.csproj
+++ b/FastFileCompilerGUI/FastFileCompilerGUI.csproj
@@ -8,9 +8,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <SelfContained>false</SelfContained>
-    <Version>3.1.0</Version>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FastFileCompilerGUI/MainForm.Designer.cs
+++ b/FastFileCompilerGUI/MainForm.Designer.cs
@@ -509,7 +509,7 @@ partial class MainForm
         this.MinimumSize = new Size(850, 500);
         this.Name = "MainForm";
         this.StartPosition = FormStartPosition.CenterScreen;
-        this.Text = "FastFile Compiler v3.1.0 - Call of Duty";
+        this.Text = "FastFile Compiler v4.0.0 - Call of Duty";
 
         this.mainTableLayout.ResumeLayout(false);
         this.topPanel.ResumeLayout(false);

--- a/FastFileConverterGUI/FastFileConverterGUI.csproj
+++ b/FastFileConverterGUI/FastFileConverterGUI.csproj
@@ -8,9 +8,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>FastFileConverter</AssemblyName>
     <RootNamespace>FastFileConverterGUI</RootNamespace>
-    <Version>3.1.0</Version>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/FastFileConverterGUI/Form1.cs
+++ b/FastFileConverterGUI/Form1.cs
@@ -30,7 +30,7 @@ public partial class Form1 : Form
 
     private void SetupUI()
     {
-        this.Text = "FastFile Platform Converter v3.1.0";
+        this.Text = "FastFile Platform Converter v4.0.0";
         this.Size = new Size(700, 600);
         this.MinimumSize = new Size(600, 500);
         this.StartPosition = FormStartPosition.CenterScreen;

--- a/FastFileExtractor/FastFileExtractor.csproj
+++ b/FastFileExtractor/FastFileExtractor.csproj
@@ -9,9 +9,9 @@
     <SelfContained>false</SelfContained>
     <AssemblyName>FastFileExtractor</AssemblyName>
     <RootNamespace>FastFileExtractor</RootNamespace>
-    <Version>3.1.0</Version>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FastFileExtractor/MainForm.Designer.cs
+++ b/FastFileExtractor/MainForm.Designer.cs
@@ -361,7 +361,7 @@ partial class MainForm
         MinimumSize = new Size(550, 400);
         Name = "MainForm";
         StartPosition = FormStartPosition.CenterScreen;
-        Text = "FastFile Extractor v3.1.0";
+        Text = "FastFile Extractor v4.0.0";
         DragDrop += MainForm_DragDrop;
         DragEnter += MainForm_DragEnter;
         tabControl.ResumeLayout(false);

--- a/FastFileLib/FastFileLib.csproj
+++ b/FastFileLib/FastFileLib.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.1.0</Version>
-    <AssemblyVersion>3.1.0</AssemblyVersion>
-    <FileVersion>3.1.0</FileVersion>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <FileVersion>4.0.0</FileVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Update project versions from 3.1.0 to 4.0.0 (Version, AssemblyVersion, FileVersion) in multiple csproj files and FastFileLib. Also update visible version strings in ApplicationConstants and UI forms (compiler, converter, extractor) to reflect the new 4.0.0 release.